### PR TITLE
Tags a list that doesn't break tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,10 @@ productionLog
 # /intermine/webservice/client/javascript/imbedding/0.2/style/
 /intermine/webservice/client/javascript/imbedding/0.2/style/*min.*
 
+# test environments
+
+config/travis/solr*
+
 # mines
 malariamine/
 

--- a/config/run-ws-tests.sh
+++ b/config/run-ws-tests.sh
@@ -18,7 +18,8 @@ if [ "$CLIENT" = "JS" ]; then
     # bower_components installed, so devs don't usually see the error,
     # but Travis always does.
     npm install acorn
-    npm install # installs deps and runs tests.
+    npm install # installs deps
+    grunt test  # runs tests
 
 elif [ "$CLIENT" = "PY" ]; then
 

--- a/testmine/webapp/src/main/resources/userprofile-withuser.xml
+++ b/testmine/webapp/src/main/resources/userprofile-withuser.xml
@@ -125,7 +125,7 @@
         </bag>
     </bags>
     <tags>
-        <tag name="privateTag" objectIdentifier="My-Favourite-Employees" type="bag"/>
+        <tag name="privateTag" objectIdentifier="Unusual departments" type="bag"/>
         <tag name="privateTag" objectIdentifier="The great unknowns" type="bag"/>
         <tag name="thisIsAPrivateTag" objectIdentifier="private-template-1" type="template"/>
         <tag name="thisIsAlsoAPrivateTag" objectIdentifier="private-template-1" type="template"/>


### PR DESCRIPTION
The previous list tag we tried adding made a bunch of tests fail. Rather than re-writing the tests, let's tag a different list.

This PR contains: 
- a differently tagged list
- gitignore for the solr setup files
- an updated command to actually run the tests for imjs. They had been previously "passing" just by installing dependencies and not actually running the tests. 